### PR TITLE
fix: handle Initial commit in version bump workflow

### DIFF
--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -41,10 +41,16 @@ jobs:
           PR_TITLE="${{ github.event.head_commit.message }}"
           echo "PR Title: $PR_TITLE"
           
-          if [[ "$PR_TITLE" =~ feat!: || "$PR_TITLE" =~ fix!: || "$PR_TITLE" =~ refactor!: ]]; then
+          # For titles containing "Initial commit", always use patch
+          if [[ "$PR_TITLE" == *"Initial commit"* ]]; then
+            echo "bump_type=patch" >> $GITHUB_OUTPUT
+          # For breaking changes
+          elif [[ "$PR_TITLE" =~ feat!: || "$PR_TITLE" =~ fix!: || "$PR_TITLE" =~ refactor!: ]]; then
             echo "bump_type=major" >> $GITHUB_OUTPUT
+          # For new features
           elif [[ "$PR_TITLE" =~ feat: ]]; then
             echo "bump_type=minor" >> $GITHUB_OUTPUT
+          # For everything else
           else
             echo "bump_type=patch" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
# Description

Fixed several issues with handling "Initial commit" in our PR validation and version bump workflows:

1. Semantic PR Check:
   - Removed outcome validation for Initial commit titles
   - Always pass verification for titles containing Initial commit
   - Fixed quote escaping in PR title handling

2. Version Bump:
   - Added Initial commit pattern matching
   - Treat Initial commit PRs as patch version changes
   - Maintained existing semantic version bump rules

These changes ensure that both new repositories using "Initial commit" and PRs discussing Initial commit functionality work correctly with our automated workflows.

## Type of Change

version: fix      # Bug fix (patch version bump)

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG